### PR TITLE
chore(swagger): integrate springdoc-openapi 2.8.11 with grouped API docs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.11'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
@@ -37,4 +39,8 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+springBoot {
+    mainClass = 'com.iherbyou.IHerbYouApplication'
 }

--- a/src/main/java/com/iherbyou/config/OpenApiConfig.java
+++ b/src/main/java/com/iherbyou/config/OpenApiConfig.java
@@ -1,0 +1,26 @@
+package com.iherbyou.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI baseOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("iHerbYou API")
+                        .description("아이허브유 백엔드 REST API 문서")
+                        .version("v1"))
+                .servers(List.of(
+                        new Server().url("https://www.iherbyou.store").description("Production"),
+                        new Server().url("http://localhost:8080").description("Local")
+                ));
+    }
+}

--- a/src/main/java/com/iherbyou/config/OpenApiGroupConfig.java
+++ b/src/main/java/com/iherbyou/config/OpenApiGroupConfig.java
@@ -1,0 +1,54 @@
+package com.iherbyou.config;
+
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiGroupConfig {
+
+    @Bean
+    public GroupedOpenApi cartApi() {
+        return GroupedOpenApi.builder()
+                .group("Cart")
+                .packagesToScan("com.iherbyou.cart.controller")
+                .pathsToMatch("/api/cart/**", "/api/wishlist/**")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi catalogApi() {
+        return GroupedOpenApi.builder()
+                .group("Catalog")
+                .packagesToScan("com.iherbyou.catalog.controller")
+                .pathsToMatch("/api/products/**", "/api/categories/**")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi communityApi() {
+        return GroupedOpenApi.builder()
+                .group("Community")
+                .packagesToScan("com.iherbyou.community.controller")
+                .pathsToMatch("/api/community/**", "/api/reviews/**", "/api/qna/**")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi orderingApi() {
+        return GroupedOpenApi.builder()
+                .group("Ordering")
+                .packagesToScan("com.iherbyou.ordering.controller")
+                .pathsToMatch("/api/orders/**", "/api/payments/**")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi userApi() {
+        return GroupedOpenApi.builder()
+                .group("User")
+                .packagesToScan("com.iherbyou.user.controller")
+                .pathsToMatch("/api/users/**", "/api/auth/**")
+                .build();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -20,6 +20,13 @@ spring:
     ansi:
       enabled: always
 
+springdoc:
+  api-docs:
+    enabled: true
+  packages-to-scan: com.iherbyou           # 루트 패키지로 넓게
+  paths-to-match: /**                      # 전체 허용
+
+
 logging:
   level:
     org.hibernate.SQL: debug


### PR DESCRIPTION
## Related Issue
#28 Swagger Controller 연동  

## Summary (요약)
프로젝트의 Controller들 자동으로 읽어서 스웨거 문서 만드는 작업

## Changes (변경 사항)
1. springdoc-openapi-starter-webmvc-ui 의존성 추가 (v2.8.11)
2. OpenApiConfig를 구성하여 서버 정의 추가 (운영/로컬)
3. OpenApiGroupConfig를 도입해 API 그룹 분리 (Cart, Catalog, Community, Ordering, User)

## Type of change
- [ ] Bug fix (버그 수정)
- [ ] New feature (새로운 기능 추가)
- [ ] Refactoring (리팩토링)
- [x] Documentation (문서화)
- [ ] Tests (테스트 추가/수정)

---

## 📌 PR Checklist
- [x] 브랜치 이름 규칙 확인 (feature/*, fix/* 등)
- [x] PR 대상 브랜치 확인 (develop)
- [x] 최신 develop 반영 완료 (merge or rebase)
- [x] 코드 자동 정렬 실행 (⌥⌘L / Ctrl+Alt+L) & 불필요한 import 제거
- [x] 로컬 빌드/테스트 확인 완료