### PR TITLE
Feature/logout - JWT Logout & Swagger Authentication Support

### DIFF
--- a/src/main/java/com/iherbyou/config/OpenApiConfig.java
+++ b/src/main/java/com/iherbyou/config/OpenApiConfig.java
@@ -1,7 +1,9 @@
 package com.iherbyou.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,6 +23,16 @@ public class OpenApiConfig {
                 .servers(List.of(
                         new Server().url("https://www.iherbyou.store").description("Production"),
                         new Server().url("http://localhost:8080").description("Local")
-                ));
+                ))
+                // JWT 인증 설정
+                .components(new Components()
+                        .addSecuritySchemes("bearerAuth",
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                                        .in(SecurityScheme.In.HEADER)
+                                        .name("Authorization")));
     }
+
 }

--- a/src/main/java/com/iherbyou/user/controller/UserController.java
+++ b/src/main/java/com/iherbyou/user/controller/UserController.java
@@ -1,14 +1,13 @@
 package com.iherbyou.user.controller;
 
-import com.iherbyou.user.dto.LoginRequestDto;
-import com.iherbyou.user.dto.LoginResponseDto;
-import com.iherbyou.user.dto.SignUpRequestDto;
-import com.iherbyou.user.dto.SignUpResponseDto;
+import com.iherbyou.security.auth.UserPrincipal;
+import com.iherbyou.user.dto.*;
 import com.iherbyou.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,6 +31,13 @@ public class UserController {
     @PostMapping("/login")
     public ResponseEntity<LoginResponseDto> login(@Valid @RequestBody LoginRequestDto request) {
         LoginResponseDto response = userService.login(request);
+        return ResponseEntity.ok(response);
+    }
+
+    // 로그아웃 (logout)
+    @PostMapping("/logout")
+    public ResponseEntity<LogoutResponseDto> logout(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+        LogoutResponseDto response = userService.logout(userPrincipal);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/iherbyou/user/dto/LogoutResponseDto.java
+++ b/src/main/java/com/iherbyou/user/dto/LogoutResponseDto.java
@@ -1,0 +1,20 @@
+package com.iherbyou.user.dto;
+
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+@Getter
+@Builder
+public class LogoutResponseDto {
+
+    private String message;
+
+    public static LogoutResponseDto success() {
+        return LogoutResponseDto.builder()
+                .message("로그아웃이 완료되었습니다.")
+                .build();
+    }
+
+}

--- a/src/main/java/com/iherbyou/user/service/UserService.java
+++ b/src/main/java/com/iherbyou/user/service/UserService.java
@@ -3,11 +3,9 @@ package com.iherbyou.user.service;
 import com.iherbyou.common.code.entity.Code;
 import com.iherbyou.common.code.service.CodeService;
 import com.iherbyou.exception.user.*;
+import com.iherbyou.security.auth.UserPrincipal;
 import com.iherbyou.security.jwt.JwtUtil;
-import com.iherbyou.user.dto.LoginRequestDto;
-import com.iherbyou.user.dto.LoginResponseDto;
-import com.iherbyou.user.dto.SignUpRequestDto;
-import com.iherbyou.user.dto.SignUpResponseDto;
+import com.iherbyou.user.dto.*;
 import com.iherbyou.user.entity.User;
 import com.iherbyou.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -114,6 +112,16 @@ public class UserService {
                 .expiresIn(jwtExpirationMs / 1000) // 초 단위로 변환
                 .message("로그인 성공")
                 .build();
+    }
+
+    /**
+     * 로그아웃 (Logout)
+     */
+    public LogoutResponseDto logout(UserPrincipal userPrincipal) {
+        log.info("logout request: {} (id: {}", userPrincipal.getEmail(), userPrincipal.getId());
+        // 서버에서는 별도 처리 없이 응답만 반환 -> client 에서 토큰을 제거해야함
+        log.info("로그아웃 완료: {}", userPrincipal.getEmail());
+        return LogoutResponseDto.success();
     }
 
 }


### PR DESCRIPTION
## 
Summary (요약)
JWT 기반 로그아웃 기능을 구현, Swagger UI에서 JWT 토큰을 사용한 API 테스트가 가능하도록 인증 설정 추가

## 
Changes (변경 사항)
1. Logout Implementation
- LogoutResponseDto: 로그아웃 응답 구조체
- UserService.logout(): 로그아웃 처리 로직 (클라이언트 토큰 삭제 방식)
- POST /api/users/logout: 로그아웃 API 엔드포인트
- JWT 토큰 검증을 통한 인증된 사용자만 로그아웃 가능
2. Swagger JWT Authentication
- OpenApiConfig 업데이트: JWT Bearer 토큰 인증 스키마 추가
- Swagger UI에서 Authorization 헤더로 JWT 토큰 설정 가능
- 보호된 API 엔드포인트 테스트 지원



## Type of change
- [ ] Bug fix (버그 수정)
- [ ] New feature (새로운 기능 추가)
- [ ] Refactoring (리팩토링)
- [ ] Documentation (문서화)
- [ ] Tests (테스트 추가/수정)

---

## 📌 PR Checklist
- [x] 브랜치 이름 규칙 확인 (feature/*, fix/* 등)
- [x] PR 대상 브랜치 확인 (develop)
- [x] 최신 develop 반영 완료 (merge or rebase)
- [x] 코드 자동 정렬 실행 (⌥⌘L / Ctrl+Alt+L) & 불필요한 import 제거
- [x] 로컬 빌드/테스트 확인 완료