### PR TITLE
fix: Return 401 instead of 403 for expired JWT tokens

### DIFF
--- a/src/main/java/com/iherbyou/security/SecurityConfig.java
+++ b/src/main/java/com/iherbyou/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.iherbyou.security;
 
 import com.iherbyou.security.filter.JwtAuthenticationFilter;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -53,6 +54,15 @@ public class SecurityConfig {
                 // 세션 사용하지 않음 (JWT 사용하므로 STATELESS)
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                // 인증되지 않은 요청 처리
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+                            response.setContentType("application/json");
+                            response.getWriter().write("{\"error\": \"Unauthorized\"}");
+                        })
+                )
 
                 // 엔드포인트 권한 (요청별 인가 설정)
                 .authorizeHttpRequests(auth -> auth

--- a/src/main/java/com/iherbyou/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/iherbyou/security/filter/JwtAuthenticationFilter.java
@@ -30,42 +30,33 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
         try {
-            // 1. 요청 헤더에서 JWT 토큰 추출
             String jwt = getJwtFromRequest(request);
 
-            if (StringUtils.hasText(jwt) && jwtUtil.validateAccessToken(jwt)) {
-                // 2. 토큰에서 사용자 이메일 추출
-                String email = jwtUtil.getEmailFromToken(jwt);
+            if (StringUtils.hasText(jwt)) {
+                if (jwtUtil.validateAccessToken(jwt)) {
+                    // 유효한 토큰 - 인증 설정
+                    String email = jwtUtil.getEmailFromToken(jwt);
+                    UserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
 
-                // 3. UserDetails 조회 (DB에서 사용자 정보 로드)
-                UserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
+                    UsernamePasswordAuthenticationToken authentication =
+                            new UsernamePasswordAuthenticationToken(
+                                    userDetails, null, userDetails.getAuthorities());
+                    authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
-                // 4. Authentication 객체 생성
-                UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(
-                                userDetails,
-                                null,
-                                userDetails.getAuthorities()
-                        );
-
-                // 5. 요청 세부 정보 설정
-                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-
-                // 6. SecurityContext에 인증 정보 설정
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-
-                log.debug("JWT 토큰으로 사용자 인증 완료: {} (URI: {})", email, request.getRequestURI());
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                    log.debug("JWT 토큰으로 사용자 인증 완료: {} (URI: {})", email, request.getRequestURI());
+                } else {
+                    // 만료되거나 유효하지 않은 토큰 - 명시적으로 SecurityContext 초기화
+                    log.debug("유효하지 않거나 만료된 토큰 (URI: {})", request.getRequestURI());
+                    SecurityContextHolder.clearContext();
+                }
             }
 
         } catch (Exception e) {
-            log.error("JWT 토큰 처리 중 오류 발생 (URI: {}): {}",
-                    request.getRequestURI(), e.getMessage());
-
-            // SecurityContext 초기화 (인증 실패)
+            log.error("JWT 토큰 처리 중 오류 발생 (URI: {}): {}", request.getRequestURI(), e.getMessage());
             SecurityContextHolder.clearContext();
         }
 
-        // 7. 다음 필터로 요청 전달
         filterChain.doFilter(request, response);
     }
 

--- a/src/main/java/com/iherbyou/user/service/UserService.java
+++ b/src/main/java/com/iherbyou/user/service/UserService.java
@@ -135,7 +135,7 @@ public class UserService {
         // refresh token 유효성 검증
         if (!jwtUtil.validateRefreshToken(refreshToken)) {
             log.warn("토큰 갱신 실패 - 유효하지 않은 Refresh Token");
-            throw new InvalidTokenException("유호하지 않은 Refresh Token입니다.");
+            throw new InvalidTokenException("유효하지 않은 Refresh Token입니다.");
         }
 
         // Refresh Token에서 사용자 이메일 추출


### PR DESCRIPTION
- Add AuthenticationEntryPoint for consistent unauthorized responses
- Explicitly clear SecurityContext when token is invalid or expired
- Improve token validation flow in JwtAuthenticationFilter
- Enable proper token refresh flow on frontend

## Summary (요약)
jwt 유효기간 만료 토큰 요청시 403 반환 -> 401 반환

## Type of change
- [ ] Bug fix (버그 수정)
- [ ] New feature (새로운 기능 추가)
- [ ] Refactoring (리팩토링)
- [ ] Documentation (문서화)
- [ ] Tests (테스트 추가/수정)

---

## 📌 PR Checklist
- [x] 브랜치 이름 규칙 확인 (feature/*, fix/* 등)
- [x] PR 대상 브랜치 확인 (develop)
- [x] 최신 develop 반영 완료 (merge or rebase)
- [x] 코드 자동 정렬 실행 (⌥⌘L / Ctrl+Alt+L) & 불필요한 import 제거
- [x] 로컬 빌드/테스트 확인 완료