### PR TITLE
fix: resolve duplicate item logic

### DIFF
--- a/src/main/java/com/iherbyou/wishlist/repository/WishlistRepository.java
+++ b/src/main/java/com/iherbyou/wishlist/repository/WishlistRepository.java
@@ -13,18 +13,11 @@ public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
      * N+1 문제 방지를 위한 fetch join
      */
     @Query("""
-            SELECT DISTINCT w 
+            SELECT w 
             FROM Wishlist w 
             LEFT JOIN FETCH w.wishlistProducts wp 
             LEFT JOIN FETCH wp.product p
-            LEFT JOIN FETCH p.productImgs
             WHERE w.user.id = :userId
             """)
     Optional<Wishlist> findByUserIdWithProducts(Long userId);
-
-    /**
-     * userId로 위시리스트 조회 (상품 정보 없이)
-     */
-    @Query("SELECT w FROM Wishlist w WHERE w.user.id = :userId")
-    Optional<Wishlist> findByUserId(Long userId);
 }

--- a/src/main/java/com/iherbyou/wishlist/service/WishlistService.java
+++ b/src/main/java/com/iherbyou/wishlist/service/WishlistService.java
@@ -108,7 +108,7 @@ public class WishlistService {
     // ========== Private Helper Methods ==========
 
     private Wishlist getOrCreateWishlist(Long userId) {
-        return wishlistRepository.findByUserIdWithProducts(userId)  // 이걸로 변경
+        return wishlistRepository.findByUserIdWithProducts(userId)
                 .orElseGet(() -> createNewWishlist(userId));
     }
 

--- a/src/main/java/com/iherbyou/wishlist/service/WishlistService.java
+++ b/src/main/java/com/iherbyou/wishlist/service/WishlistService.java
@@ -108,7 +108,7 @@ public class WishlistService {
     // ========== Private Helper Methods ==========
 
     private Wishlist getOrCreateWishlist(Long userId) {
-        return wishlistRepository.findByUserId(userId)
+        return wishlistRepository.findByUserIdWithProducts(userId)  // 이걸로 변경
                 .orElseGet(() -> createNewWishlist(userId));
     }
 


### PR DESCRIPTION
## Summary (요약)
위시리스트 아이템 중복 추가 방지 

## Changes (변경 사항)
1. Fix duplicate item display caused by JOIN FETCH cartesian product

## Type of change
- [x] Bug fix (버그 수정)
- [ ] New feature (새로운 기능 추가)
- [ ] Refactoring (리팩토링)
- [ ] Documentation (문서화)
- [ ] Tests (테스트 추가/수정)

---

## 📌 PR Checklist
- [x] 브랜치 이름 규칙 확인 (feature/*, fix/* 등)
- [x] PR 대상 브랜치 확인 (develop)
- [x] 최신 develop 반영 완료 (merge or rebase)
- [x] 코드 자동 정렬 실행 (⌥⌘L / Ctrl+Alt+L) & 불필요한 import 제거
- [x] 로컬 빌드/테스트 확인 완료