### PR TITLE
feat/password reset 비밀번호 재설정

### DIFF
--- a/src/main/java/com/iherbyou/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/iherbyou/exception/GlobalExceptionHandler.java
@@ -5,6 +5,9 @@ import com.iherbyou.exception.catalog.*;
 import com.iherbyou.exception.email.AlreadyVerifiedTokenException;
 import com.iherbyou.exception.email.ExpiredEmailTokenException;
 import com.iherbyou.exception.email.InvalidEmailTokenException;
+import com.iherbyou.exception.password.ExpiredPasswordResetTokenException;
+import com.iherbyou.exception.password.InvalidPasswordResetTokenException;
+import com.iherbyou.exception.password.UsedPasswordResetTokenException;
 import com.iherbyou.exception.user.*;
 import com.iherbyou.exception.wishlist.*;
 import org.springframework.http.HttpStatus;
@@ -77,6 +80,23 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(AlreadyVerifiedTokenException.class)
     public ResponseEntity<Map<String, Object>> handleAlreadyVerifiedEmail(AlreadyVerifiedTokenException e) {
+        return buildResponse(HttpStatus.CONFLICT, e.getMessage());
+    }
+
+    // ===================== 비밀번호 재설정 관련 예외 =====================
+
+    @ExceptionHandler(InvalidPasswordResetTokenException.class)
+    public ResponseEntity<Map<String, Object>> handleInvalidPasswordResetToken(InvalidPasswordResetTokenException e) {
+        return buildResponse(HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
+    @ExceptionHandler(ExpiredPasswordResetTokenException.class)
+    public ResponseEntity<Map<String, Object>> handleExpiredPasswordResetToken(ExpiredPasswordResetTokenException e) {
+        return buildResponse(HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
+    @ExceptionHandler(UsedPasswordResetTokenException.class)
+    public ResponseEntity<Map<String, Object>> handleUsedPasswordResetToken(UsedPasswordResetTokenException e) {
         return buildResponse(HttpStatus.CONFLICT, e.getMessage());
     }
 

--- a/src/main/java/com/iherbyou/exception/password/ExpiredPasswordResetTokenException.java
+++ b/src/main/java/com/iherbyou/exception/password/ExpiredPasswordResetTokenException.java
@@ -1,0 +1,7 @@
+package com.iherbyou.exception.password;
+
+public class ExpiredPasswordResetTokenException extends RuntimeException {
+    public ExpiredPasswordResetTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/iherbyou/exception/password/InvalidPasswordResetTokenException.java
+++ b/src/main/java/com/iherbyou/exception/password/InvalidPasswordResetTokenException.java
@@ -1,0 +1,7 @@
+package com.iherbyou.exception.password;
+
+public class InvalidPasswordResetTokenException extends RuntimeException {
+    public InvalidPasswordResetTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/iherbyou/exception/password/UsedPasswordResetTokenException.java
+++ b/src/main/java/com/iherbyou/exception/password/UsedPasswordResetTokenException.java
@@ -1,0 +1,7 @@
+package com.iherbyou.exception.password;
+
+public class UsedPasswordResetTokenException extends RuntimeException {
+    public UsedPasswordResetTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/iherbyou/security/SecurityConfig.java
+++ b/src/main/java/com/iherbyou/security/SecurityConfig.java
@@ -72,6 +72,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/users/signup", "/api/users/login").permitAll()
                         .requestMatchers("/api/users/verify-email", "/api/users/resend-verification").permitAll() // 이메일 인증
                         .requestMatchers("/api/auth/refresh").permitAll()
+                        .requestMatchers(("/api/users/reset-password-request")).permitAll() // 비밀번호 재설정 요청
+                        .requestMatchers("/api/users/reset-password-confirm").permitAll()
                         .requestMatchers("/api/banner/**").permitAll()
                         .requestMatchers("/api/codes/**").permitAll()
                         .requestMatchers("/api/catalog/**").permitAll()

--- a/src/main/java/com/iherbyou/security/SecurityConfig.java
+++ b/src/main/java/com/iherbyou/security/SecurityConfig.java
@@ -72,8 +72,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/users/signup", "/api/users/login").permitAll()
                         .requestMatchers("/api/users/verify-email", "/api/users/resend-verification").permitAll() // 이메일 인증
                         .requestMatchers("/api/auth/refresh").permitAll()
-                        .requestMatchers(("/api/users/reset-password-request")).permitAll() // 비밀번호 재설정 요청
-                        .requestMatchers("/api/users/reset-password-confirm").permitAll()
+                        .requestMatchers("/api/users/password-reset-request").permitAll() // 비밀번호 재설정 요청
+                        .requestMatchers("/api/users/password-reset-confirm").permitAll()
                         .requestMatchers("/api/banner/**").permitAll()
                         .requestMatchers("/api/codes/**").permitAll()
                         .requestMatchers("/api/catalog/**").permitAll()

--- a/src/main/java/com/iherbyou/user/controller/UserController.java
+++ b/src/main/java/com/iherbyou/user/controller/UserController.java
@@ -40,6 +40,20 @@ public class UserController {
         return ResponseEntity.ok(EmailVerificationResponseDto.resendSuccess());
     }
 
+    // 비밀번호 재설정 요청
+    @PostMapping("/password-reset-request")
+    public ResponseEntity<ResetPasswordResponseDto> requestPasswordReset(@Valid @RequestBody ResetPasswordRequestDto request) {
+        ResetPasswordResponseDto response = userService.requestResetPassword(request);
+        return ResponseEntity.ok(response);
+    }
+
+    // 비밀번호 재설정 확인
+    @PostMapping("/password-reset-confirm")
+    public ResponseEntity<ResetPasswordResponseDto> resetPassword(@RequestParam String token, @Valid @RequestBody ResetPasswordConfirmDto request) {
+        ResetPasswordResponseDto response = userService.resetPassword(token, request);
+        return ResponseEntity.ok(response);
+    }
+
     // 로그인 (login)
     @PostMapping("/login")
     public ResponseEntity<LoginResponseDto> login(@Valid @RequestBody LoginRequestDto request) {

--- a/src/main/java/com/iherbyou/user/dto/ResetPasswordConfirmDto.java
+++ b/src/main/java/com/iherbyou/user/dto/ResetPasswordConfirmDto.java
@@ -1,0 +1,18 @@
+package com.iherbyou.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+@Getter
+@Builder
+public class ResetPasswordConfirmDto {
+
+    // 토큰은 url query parameter로 받는다. 사용자는 비밀번호만 입력하면 됨.
+    @NotBlank(message = "새 비밀번호는 필수입니다.")
+    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+    private String newPassword;
+}

--- a/src/main/java/com/iherbyou/user/dto/ResetPasswordRequestDto.java
+++ b/src/main/java/com/iherbyou/user/dto/ResetPasswordRequestDto.java
@@ -1,0 +1,17 @@
+package com.iherbyou.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+@Getter
+@Builder
+public class ResetPasswordRequestDto {
+
+    @NotBlank
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+}

--- a/src/main/java/com/iherbyou/user/dto/ResetPasswordResponseDto.java
+++ b/src/main/java/com/iherbyou/user/dto/ResetPasswordResponseDto.java
@@ -1,0 +1,25 @@
+package com.iherbyou.user.dto;
+
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+@Getter
+@Builder
+public class ResetPasswordResponseDto {
+
+    private String message;
+
+    public static ResetPasswordResponseDto requestSuccess() {
+        return ResetPasswordResponseDto.builder()
+                .message("비밀번호 재설정 이메일이 발송되었습니다. 이메일을 확인해주세요.")
+                .build();
+    }
+
+    public static ResetPasswordResponseDto resetSuccess() {
+        return ResetPasswordResponseDto.builder()
+                .message("비밀번호가 성공적으로 변경되었습니다. 새 비밀번호로 로그인해주세요.")
+                .build();
+    }
+}

--- a/src/main/java/com/iherbyou/user/entity/PasswordResetToken.java
+++ b/src/main/java/com/iherbyou/user/entity/PasswordResetToken.java
@@ -1,0 +1,57 @@
+package com.iherbyou.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@Entity
+public class PasswordResetToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt; // 만료 시간 (1시간 후)
+
+    @Column
+    private LocalDateTime usedAt; // 사용 완료 시간
+
+    /**
+     * Business Methods
+     */
+    // 토큰 만료 여부 확인
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
+    }
+
+    // 이미 사용된 토큰인지 확인
+    public boolean isUsed() {
+        return usedAt != null;
+    }
+
+    // 토큰 사용 처리
+    public void markAsUsed() {
+        this.usedAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/com/iherbyou/user/repository/PasswordResetTokenRepository.java
+++ b/src/main/java/com/iherbyou/user/repository/PasswordResetTokenRepository.java
@@ -1,0 +1,19 @@
+package com.iherbyou.user.repository;
+
+import com.iherbyou.user.entity.PasswordResetToken;
+import com.iherbyou.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Long> {
+
+    // 토큰 문자열로 조회
+    Optional<PasswordResetToken> findByToken(String token);
+
+    // 사용자의 모든 토큰 삭제 (재발송 시)
+    void deleteByUser(User user);
+
+}

--- a/src/main/java/com/iherbyou/user/service/EmailService.java
+++ b/src/main/java/com/iherbyou/user/service/EmailService.java
@@ -63,7 +63,7 @@ public class EmailService {
             helper.setSubject("[iHerbYou] 비밀번호 재설정 안내");
 
             // 재설정 링크 생성
-            String resetUrl = baseUrl + "/api/users/reset-password?token=" + token;
+            String resetUrl = baseUrl + "/api/users/reset-password-confirm?token=" + token;
 
             String htmlContent = buildPasswordResetEmailHtml(resetUrl);
             helper.setText(htmlContent, true);

--- a/src/main/java/com/iherbyou/user/service/EmailService.java
+++ b/src/main/java/com/iherbyou/user/service/EmailService.java
@@ -48,7 +48,33 @@ public class EmailService {
             log.error("이메일 발송 실패: {}", toEmail, e);
             throw new RuntimeException("이메일 발송에 실패했습니다", e);
         }
+    }
 
+    /**
+     * 비밀번호 재설정 메일 발송
+     */
+    public void sendPasswordResetEmail(String toEmail, String token) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setFrom(fromEmail);
+            helper.setTo(toEmail);
+            helper.setSubject("[iHerbYou] 비밀번호 재설정 안내");
+
+            // 재설정 링크 생성
+            String resetUrl = baseUrl + "/api/users/reset-password?token=" + token;
+
+            String htmlContent = buildPasswordResetEmailHtml(resetUrl);
+            helper.setText(htmlContent, true);
+
+            mailSender.send(message);
+            log.info("비밀번호 재설정 메일 발송 완료: {}", toEmail);
+
+        } catch (MessagingException e) {
+            log.error("비밀번호 재설정 메일 발송 실패: {}", toEmail, e);
+            throw new RuntimeException("이메일 발송에 실패했습니다", e);
+        }
     }
 
     /**
@@ -86,6 +112,50 @@ public class EmailService {
                 </body>
                 </html>
                 """.formatted(verificationUrl, verificationUrl, verificationUrl);
+    }
+
+    /**
+     * 비밀번호 재설정 메일 HTML 생성
+     */
+    private String buildPasswordResetEmailHtml(String resetUrl) {
+        return """
+                <!DOCTYPE html>
+                <html>
+                <head>
+                    <meta charset="UTF-8">
+                </head>
+                <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+                    <div style="max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #ddd; border-radius: 10px;">
+                        <h2 style="color: #4CAF50;">비밀번호 재설정 안내</h2>
+                        <p>안녕하세요,</p>
+                        <p>비밀번호 재설정 요청을 받았습니다.</p>
+                        <p>아래 버튼을 클릭하여 새로운 비밀번호를 설정해주세요.</p>
+                        <div style="text-align: center; margin: 30px 0;">
+                            <a href="%s" 
+                               style="display: inline-block; padding: 12px 24px; background-color: #4CAF50; 
+                                      color: white; text-decoration: none; border-radius: 5px; font-weight: bold;">
+                                비밀번호 재설정하기
+                            </a>
+                        </div>
+                        <p style="color: #666; font-size: 14px;">
+                            링크가 작동하지 않는 경우, 아래 URL을 복사하여 브라우저에 붙여넣으세요:<br>
+                            <a href="%s" style="color: #4CAF50;">%s</a>
+                        </p>
+                        <p style="color: #ff6b6b; font-size: 14px; font-weight: bold;">
+                            이 링크는 1시간 동안만 유효합니다.
+                        </p>
+                        <p style="color: #666; font-size: 14px;">
+                            본인이 요청하지 않았다면 이 메일을 무시하셔도 됩니다.<br>
+                            비밀번호는 변경되지 않습니다.
+                        </p>
+                        <p style="color: #999; font-size: 12px; margin-top: 30px; border-top: 1px solid #eee; padding-top: 20px;">
+                            본 메일은 발신 전용입니다. 문의사항은 고객센터를 이용해주세요.<br>
+                            © 2025 아이허브유. All rights reserved.
+                        </p>
+                    </div>
+                </body>
+                </html>
+                """.formatted(resetUrl, resetUrl, resetUrl);
     }
 
 }

--- a/src/main/java/com/iherbyou/user/service/EmailService.java
+++ b/src/main/java/com/iherbyou/user/service/EmailService.java
@@ -22,8 +22,11 @@ public class EmailService {
     @Value("${app.base-url}")
     private String baseUrl;
 
+    @Value("${app.frontend-url}")
+    private String frontendUrl;
+
     /**
-     * 이메일 인증 메일 발송
+     * 이메일 인증 메일 발송 (회원가입시)
      */
     public void sendVerificationEmail(String toEmail, String token) {
         try {
@@ -34,8 +37,8 @@ public class EmailService {
             helper.setTo(toEmail); // 회원가입 한 사람의 email (받는 사람 이메일 설정)
             helper.setSubject("[iHerbYou] [verification email] 이메일 인증을 완료해주세요");
 
-            // 인증 링크 생성
-            String verificationUrl = baseUrl + "/api/users/verify-email?token=" + token;
+            // 인증 링크 생성 (frontend 페이지로 연결)
+            String verificationUrl = frontendUrl + "/verify-email?token=" + token;
 
             // HTML 이메일 본문
             String htmlContent = buildVerificationEmailHtml(verificationUrl);
@@ -62,8 +65,8 @@ public class EmailService {
             helper.setTo(toEmail);
             helper.setSubject("[iHerbYou] 비밀번호 재설정 안내");
 
-            // 재설정 링크 생성
-            String resetUrl = baseUrl + "/api/users/reset-password-confirm?token=" + token;
+            // 재설정 링크 생성 (frontend 페이지로 연결)
+            String resetUrl = frontendUrl + "/reset-password?token=" + token;
 
             String htmlContent = buildPasswordResetEmailHtml(resetUrl);
             helper.setText(htmlContent, true);

--- a/src/main/java/com/iherbyou/user/service/UserService.java
+++ b/src/main/java/com/iherbyou/user/service/UserService.java
@@ -5,13 +5,18 @@ import com.iherbyou.common.code.service.CodeService;
 import com.iherbyou.exception.email.AlreadyVerifiedTokenException;
 import com.iherbyou.exception.email.ExpiredEmailTokenException;
 import com.iherbyou.exception.email.InvalidEmailTokenException;
+import com.iherbyou.exception.password.ExpiredPasswordResetTokenException;
+import com.iherbyou.exception.password.InvalidPasswordResetTokenException;
+import com.iherbyou.exception.password.UsedPasswordResetTokenException;
 import com.iherbyou.exception.user.*;
 import com.iherbyou.security.auth.UserPrincipal;
 import com.iherbyou.security.jwt.JwtUtil;
 import com.iherbyou.user.dto.*;
 import com.iherbyou.user.entity.EmailVerificationToken;
+import com.iherbyou.user.entity.PasswordResetToken;
 import com.iherbyou.user.entity.User;
 import com.iherbyou.user.repository.EmailVerificationTokenRepository;
+import com.iherbyou.user.repository.PasswordResetTokenRepository;
 import com.iherbyou.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +38,7 @@ public class UserService {
     private final JwtUtil jwtUtil; // JWT Utility 추가
     private final EmailService emailService;
     private final EmailVerificationTokenRepository emailVerificationTokenRepository;
+    private final PasswordResetTokenRepository passwordResetTokenRepository;
 
     /**
      * 회원가입 (SignUp)
@@ -172,6 +178,70 @@ public class UserService {
         log.info("이메일 인증 재발송 완료: {}", email);
     }
 
+    /**
+     * 비밀번호 재설정 요청 (이메일 발송) -> 비밀번호 분실 시 사용
+     */
+    @Transactional
+    public ResetPasswordResponseDto requestResetPassword(ResetPasswordRequestDto request) {
+        log.info("비밀번호 재설정 요청: {}", request.getEmail());
+
+        // 사용자 조회
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new UserNotFoundException("해당 이메일로 가입된 사용자가 없습니다"));
+
+        // 기존 토큰 삭제
+        passwordResetTokenRepository.deleteByUser(user);
+
+        // 새 토큰 생성
+        String token = UUID.randomUUID().toString();
+        PasswordResetToken resetToken = PasswordResetToken.builder()
+                .token(token)
+                .user(user)
+                .expiresAt(LocalDateTime.now().plusHours(1))
+                .build();
+
+        passwordResetTokenRepository.save(resetToken);
+
+        // 이메일 발송
+        emailService.sendPasswordResetEmail(user.getEmail(), token);
+        log.info("비밀번호 재설정 이메일 발송 완료: {}", user.getEmail());
+
+        return ResetPasswordResponseDto.requestSuccess();
+    }
+
+    /**
+     * 비밀번호 재설정 확인 (실제 변경)
+     */
+    @Transactional
+    public ResetPasswordResponseDto resetPassword(String token, ResetPasswordConfirmDto request) {
+        log.info("비밀번호 재설정 시도: token={}", token.substring(0, 10) + "...");
+
+        // token 조회
+        PasswordResetToken passwordResetToken = passwordResetTokenRepository.findByToken(token)
+                .orElseThrow(() -> new InvalidPasswordResetTokenException("유효하지 않거나 이미 사용된 토큰입니다."));
+
+        // 이미 사용된 토큰인지 확인
+        if (passwordResetToken.isUsed()) {
+            throw new UsedPasswordResetTokenException("이미 사용된 토큰입니다.");
+        }
+
+        // 토큰 만료 확인
+        if (passwordResetToken.isExpired()) {
+            throw new ExpiredPasswordResetTokenException("만료된 토큰입니다. 재발송을 요청해주세요");
+        }
+
+        // 사용자 비밀번호 변경
+        User user = passwordResetToken.getUser();
+        user.changePassword(passwordEncoder.encode(request.getNewPassword())); // 새로운 비밀번호 암호화 해서 재설정
+
+        // 토큰 사용 처리
+        passwordResetToken.markAsUsed();
+        passwordResetTokenRepository.delete(passwordResetToken); // 토큰 삭제
+        log.info("비밀번호 재설정 완료 및 토큰 삭제: {}", user.getEmail());
+
+        return ResetPasswordResponseDto.resetSuccess();
+    }
+
 
     /**
      * 로그인 (Login) - JWT 토큰 생성해서 반환
@@ -269,7 +339,7 @@ public class UserService {
     }
 
     /**
-     * 비밀번호 변경 (Change Password)
+     * 비밀번호 변경 (Change Password) : 비밀번호를 알고있는 상태에서 변경 시도. (로그인한 상태)
      */
     @Transactional
     public ChangePasswordResponseDto changePassword(ChangePasswordRequestDto request, UserPrincipal userPrincipal) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -70,3 +70,4 @@ jwt:
 
 app: # 이메일 인증 부분에서 링크
   base-url: http://localhost:8080 # 배포 후에는 주소 변경 필요
+  frontend-url: http://localhost:5173 # 배포 후에는 주소 변경 필요


### PR DESCRIPTION
## Summary (요약)
사용자가 비밀번호를 잊어버렸을 때, 이메일 인증을 통해 비밀번호를 재설정할 수 있는 기능 구현
이메일로 발송된 링크를 통해 1시간 이내에 새로운 비밀번호 설정 가능, 토큰은 1회용으로 보안 강화

## Changes (변경 사항)

### 새로운 기능
- 비밀번호 재설정 요청 기능 (이메일 발송)
- 비밀번호 재설정 확인 기능 (실제 비밀번호 변경)
- 토큰 기반 인증 시스템 (1시간 유효, 1회용)

### 추가된 엔티티 & 레포지토리
- `PasswordResetToken` 엔티티 생성
- `PasswordResetTokenRepository` 생성

### 이메일 서비스
- `EmailService`에 비밀번호 재설정 이메일 발송 기능 추가
- 이메일 링크를 프론트엔드 URL로 변경 (기존: 백엔드 API → 변경: 프론트엔드 페이지)
- `application.yaml`에 `frontend-url` 설정 추가

### 추가된 API 엔드포인트
1. 비밀번호 재설정 요청: POST /api/users/password-reset-request
2. 비밀번호 재설정 확인: POST /api/users/password-reset-confirm?token={토큰값}

## Type of change
- [ ] Bug fix (버그 수정)
- [x] New feature (새로운 기능 추가)
- [x] Refactoring (리팩토링)
- [ ] Documentation (문서화)
- [ ] Tests (테스트 추가/수정)

---

## 📌 PR Checklist
- [x] 브랜치 이름 규칙 확인 (feature/*, fix/* 등)
- [x] PR 대상 브랜치 확인 (develop)
- [x] 최신 develop 반영 완료 (merge or rebase)
- [x] 코드 자동 정렬 실행 (⌥⌘L / Ctrl+Alt+L) & 불필요한 import 제거
- [x] 로컬 빌드/테스트 확인 완료