### PR TITLE
feat/user withdrawal (회원 탈퇴)

### DIFF
--- a/src/main/java/com/iherbyou/user/controller/UserController.java
+++ b/src/main/java/com/iherbyou/user/controller/UserController.java
@@ -84,4 +84,14 @@ public class UserController {
         return ResponseEntity.ok(response);
     }
 
+    // 회원 탈퇴
+    @Operation(summary = "회원 탈퇴", description = "비밀번호 확인 후 계정을 탈퇴처리 (soft delete)")
+    @PostMapping("/withdraw")
+    public ResponseEntity<WithdrawResponseDto> withdraw(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody WithdrawRequestDto request) {
+        WithdrawResponseDto response = userService.withdraw(userPrincipal, request);
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/com/iherbyou/user/dto/WithdrawRequestDto.java
+++ b/src/main/java/com/iherbyou/user/dto/WithdrawRequestDto.java
@@ -1,0 +1,15 @@
+package com.iherbyou.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+@Getter
+@Builder
+public class WithdrawRequestDto {
+
+    @NotBlank(message = "비밀번호 입력은 필수입니다.")
+    private String password;
+}

--- a/src/main/java/com/iherbyou/user/dto/WithdrawResponseDto.java
+++ b/src/main/java/com/iherbyou/user/dto/WithdrawResponseDto.java
@@ -1,0 +1,20 @@
+package com.iherbyou.user.dto;
+
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+@Getter
+@Builder
+public class WithdrawResponseDto {
+
+    private String message;
+
+    public static WithdrawResponseDto success() {
+        return WithdrawResponseDto.builder()
+                .message("회원 탈퇴가 완료되었습니다. 그동안 iherbyou를 이용해 주셔서 감사합니다.")
+                .build();
+    }
+
+}

--- a/src/main/java/com/iherbyou/user/service/UserService.java
+++ b/src/main/java/com/iherbyou/user/service/UserService.java
@@ -367,4 +367,32 @@ public class UserService {
         return ChangePasswordResponseDto.success();
     }
 
+    /**
+     * 회원 탈퇴 (soft delete)
+     */
+    @Transactional
+    public WithdrawResponseDto withdraw(UserPrincipal userPrincipal, WithdrawRequestDto request) {
+        log.info("회원 탈퇴 시도: {}", userPrincipal.getEmail());
+
+        // 회원 확인
+        User user = userRepository.findById(userPrincipal.getId())
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다"));
+
+        // 비밀번호 일치 여부 확인
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            log.warn("회원 탈퇴 실패 - 비밀번호 불일치: {}", userPrincipal.getEmail());
+            throw new InvalidPasswordException("비밀번호가 올바르지 않습니다");
+        }
+
+        // 회원 상태 코드 DELETED로 변경 (soft delete)
+        Code deletedStatus = codeService.getCode(71, 715); // DELETED
+        if (deletedStatus == null) {
+            throw new IllegalStateException("탈퇴 상태 코드를 찾을 수 없습니다.");
+        }
+        user.changeUserStatus(deletedStatus);
+        log.info("회원 탈퇴 완료: {}", user.getEmail());
+
+        return WithdrawResponseDto.success();
+    }
+
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -70,4 +70,4 @@ jwt:
 
 app: # 이메일 인증 부분에서 링크
   base-url: http://localhost:8080 # 배포 후에는 주소 변경 필요
-  frontend-url: http://localhost:5173 # 배포 후에는 주소 변경 필요
+  frontend-url: http://localhost:5173 # 배포 후에는 주소 변경 필요 -> https://www.iherbyou.store/


### PR DESCRIPTION
## Summary (요약)
사용자가 서비스를 더 이상 이용하지 않을 때 계정을 탈퇴할 수 있는 기능 구현. 
Hard Delete가 아닌 Soft Delete 방식으로 구현 (사용자 상태를 DELETED로 변경, 탈퇴 후에는 로그인이 불가능하도록 처리)
비밀번호 확인을 통해 본인 인증 후 탈퇴 진행.


## Changes (변경 사항)
1. 회원 탈퇴 기능 구현 (Soft Delete 방식)
2. 비밀번호 확인을 통한 본인 인증

## 추가된 API 엔드포인트
1. 회원 탈퇴: POST /api/users/withdraw

## 데이터베이스
- USER_STATUS 코드 사용- `715 - DELETED` (탈퇴)
- 탈퇴 후 `findActiveUserByEmail()` 쿼리에서 자동 필터링 (상태가 ACTIVE인 user만 나오도록)

## 기타
- Soft Delete 방식으로 데이터는 보관
- 탈퇴 회원은 로그인 불가
- 재가입 시 기존 이메일 사용 불가 (DELETED 상태 계정 존재)
- `application.yaml`에 배포 URL 주석 추가

## Type of change
- [ ] Bug fix (버그 수정)
- [x] New feature (새로운 기능 추가)
- [ ] Refactoring (리팩토링)
- [ ] Documentation (문서화)
- [ ] Tests (테스트 추가/수정)

---

## 📌 PR Checklist
- [x] 브랜치 이름 규칙 확인 (feature/*, fix/* 등)
- [x] PR 대상 브랜치 확인 (develop)
- [x] 최신 develop 반영 완료 (merge or rebase)
- [x] 코드 자동 정렬 실행 (⌥⌘L / Ctrl+Alt+L) & 불필요한 import 제거
- [x] 로컬 빌드/테스트 확인 완료